### PR TITLE
Updating printer.android.ts to import utils directly from @nativescri…

### DIFF
--- a/src/printer.android.ts
+++ b/src/printer.android.ts
@@ -1,4 +1,5 @@
-import { Application, Frame, Utils, View } from "@nativescript/core";
+import { Application, Frame, View } from "@nativescript/core";
+import * as utils from '@nativescript/core/utils/utils';
 import { PrinterApi, PrintImageOptions, PrintOptions, PrintPDFOptions, PrintScreenOptions } from "./printer.common";
 
 declare let android, global: any;
@@ -14,7 +15,7 @@ export class Printer implements PrinterApi {
   private printManager: any; // android.print.PrintManager;
 
   constructor() {
-    this.printManager = Utils.ad.getApplicationContext().getSystemService(android.content.Context.PRINT_SERVICE);
+    this.printManager = utils.ad.getApplicationContext().getSystemService(android.content.Context.PRINT_SERVICE);
   }
 
   private static isPrintingSupported(): boolean {


### PR DESCRIPTION
…pt/core/utils/utils to fix a compatibility issue with NS 6.

When I use nativescript-printer v2 on an Android Application, the application crashes when I try to print. Previous versions of @nativescript/core don't have 'ad' in the Utils export. If I change the import to @nativescript/core/utils/utils, I get can get utils.ad and the application no longer crashes.